### PR TITLE
add check if logs length > 2000 characters

### DIFF
--- a/src/commands/show_logs.py
+++ b/src/commands/show_logs.py
@@ -31,4 +31,7 @@ class ApplicationCommand(Interaction):
 
         last_logs = "".join(logs[-20:])
 
+        if len(last_logs > 2000):
+            last_logs = "".join(logs[-20:])
+
         await context.send(content=f"```{last_logs}```")

--- a/src/commands/show_logs.py
+++ b/src/commands/show_logs.py
@@ -31,7 +31,7 @@ class ApplicationCommand(Interaction):
 
         last_logs = "".join(logs[-20:])
 
-        if len(last_logs > 2000):
+        if len(last_logs) > 2000:
             last_logs = "".join(logs[-20:])
 
         await context.send(content=f"```{last_logs}```")

--- a/src/commands/show_logs.py
+++ b/src/commands/show_logs.py
@@ -32,6 +32,6 @@ class ApplicationCommand(Interaction):
         last_logs = "".join(logs[-20:])
 
         if len(last_logs) > 2000:
-            last_logs = "".join(logs[-20:])
+            last_logs = "".join(logs[-10:])
 
         await context.send(content=f"```{last_logs}```")


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent potential issues when displaying long logs.