### PR TITLE
add xp command (owner only) and permissions system

### DIFF
--- a/src/commands/giveExperience.ts
+++ b/src/commands/giveExperience.ts
@@ -35,7 +35,7 @@ const giveExperienceCommand: CommandInterface = {
     user.setExperience(amount);
     await user.save();
     interaction.reply(
-      `${amount} experience gived to ${targetUser.username} ! ✅`
+      `${amount} experience given to ${targetUser.username} ! ✅`
     );
   },
 };

--- a/src/commands/giveExperience.ts
+++ b/src/commands/giveExperience.ts
@@ -1,0 +1,42 @@
+import { InteractionContextType, SlashCommandBuilder } from "discord.js";
+import { CommandInterface } from "../types/command";
+import { User } from "../database/database";
+import { CustomChatInputCommandInteraction } from "../types/customInteraction";
+import { PERMISSIONS_LEVEL } from "../enums/permissionsLevel";
+
+const giveExperienceCommand: CommandInterface = {
+  permission_level: PERMISSIONS_LEVEL.OWNER,
+  data: new SlashCommandBuilder()
+    .setName("addexperience")
+    .setDescription("Add experience to targeted user.")
+    .setContexts(InteractionContextType.Guild)
+    .addUserOption((option) =>
+      option
+        .setName("user")
+        .setDescription("Give experience to ...")
+        .setRequired(true)
+    )
+    .addIntegerOption((option) =>
+      option
+        .setName("amount")
+        .setDescription("Amount of experience to give...")
+        .setRequired(true)
+    ),
+  async execute(interaction: CustomChatInputCommandInteraction) {
+    const amount = interaction.options.getInteger("amount", true);
+    let user;
+    user = await User.findOne({
+      where: { userId: interaction.user.id },
+    });
+    if (!user) {
+      user = await User.create({ userId: interaction.user.id });
+    }
+    user.setExperience(amount);
+    await user.save();
+    interaction.reply(
+      `${amount} experience gived to ${interaction.user.username} ! ✅`
+    );
+  },
+};
+
+export default giveExperienceCommand;

--- a/src/commands/giveExperience.ts
+++ b/src/commands/giveExperience.ts
@@ -24,17 +24,18 @@ const giveExperienceCommand: CommandInterface = {
     ),
   async execute(interaction: CustomChatInputCommandInteraction) {
     const amount = interaction.options.getInteger("amount", true);
+    const targetUser = interaction.options.getUser("user", true);
     let user;
     user = await User.findOne({
-      where: { userId: interaction.user.id },
+      where: { userId: targetUser.id },
     });
     if (!user) {
-      user = await User.create({ userId: interaction.user.id });
+      user = await User.create({ userId: targetUser.id });
     }
     user.setExperience(amount);
     await user.save();
     interaction.reply(
-      `${amount} experience gived to ${interaction.user.username} ! ✅`
+      `${amount} experience gived to ${targetUser.username} ! ✅`
     );
   },
 };

--- a/src/commands/profil.ts
+++ b/src/commands/profil.ts
@@ -3,9 +3,10 @@ import { CommandInterface } from "../types/command";
 
 import { CustomChatInputCommandInteraction } from "../types/customInteraction";
 import { User } from "../database/database";
+import { PERMISSIONS_LEVEL } from "../enums/permissionsLevel";
 
 const questionCommand: CommandInterface = {
-  isAdministratorCommand: false,
+  permission_level: PERMISSIONS_LEVEL.USER,
   data: new SlashCommandBuilder()
     .setName("profil")
     .setDescription("Mon profil"),

--- a/src/commands/question.ts
+++ b/src/commands/question.ts
@@ -11,9 +11,10 @@ import { CommandInterface } from "../types/command";
 import { Question, User } from "../database/database";
 import { CustomChatInputCommandInteraction } from "../types/customInteraction";
 import { buildContainer } from "../ui/container";
+import { PERMISSIONS_LEVEL } from "../enums/permissionsLevel";
 
 const questionCommand: CommandInterface = {
-  isAdministratorCommand: false,
+  permission_level: PERMISSIONS_LEVEL.USER,
   data: new SlashCommandBuilder()
     .setName("question")
     .setDescription("Question psy..."),

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -4,11 +4,12 @@ import { CustomChatInputCommandInteraction } from "../types/customInteraction";
 import { Question, Answer } from "../database/database";
 import { Readable } from "stream";
 import csv from "csv-parser";
+import { PERMISSIONS_LEVEL } from "../enums/permissionsLevel";
 
 const ACCEPTED_EXTENSIONS = ["csv", "json"];
 
 const uploadCommand: CommandInterface = {
-  isAdministratorCommand: true,
+  permission_level: PERMISSIONS_LEVEL.ADMINISTRATOR,
   data: new SlashCommandBuilder()
     .setName("upload")
     .setDescription("commande pour upload des commands")

--- a/src/enums/permissionsLevel.ts
+++ b/src/enums/permissionsLevel.ts
@@ -1,0 +1,5 @@
+export enum PERMISSIONS_LEVEL {
+  "USER",
+  "ADMINISTRATOR",
+  "OWNER",
+}

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,8 +1,8 @@
 import { EmbedBuilder, Events, MessageFlags } from "discord.js";
 import { EventInterface } from "../types/event";
-
 import { CustomChatInputCommandInteraction } from "../types/customInteraction";
 import { Cooldowns } from "../utils/cooldowns";
+import { PERMISSIONS_LEVEL } from "../enums/permissionsLevel";
 
 const InteractionCreate: EventInterface = {
   name: Events.InteractionCreate,
@@ -24,12 +24,21 @@ const InteractionCreate: EventInterface = {
       );
     }
     if (
-      command.isAdministratorCommand &&
+      command.permission_level === PERMISSIONS_LEVEL.ADMINISTRATOR &&
       !interaction.memberPermissions?.has("Administrator")
     ) {
       return await sendErrorEmbed(
         interaction,
         "Vous ne pouvez pas utiliser la commande suivante !"
+      );
+    }
+    if (
+      command.permission_level === PERMISSIONS_LEVEL.OWNER &&
+      interaction.user.id !== "467818337599225866"
+    ) {
+      return await sendErrorEmbed(
+        interaction,
+        "Vous ne pouvez pas utiliser cette commande !"
       );
     }
     try {

--- a/src/types/command.d.ts
+++ b/src/types/command.d.ts
@@ -4,10 +4,11 @@ import {
   SlashCommandOptionsOnlyBuilder,
 } from "discord.js";
 import { CustomInteraction } from "./customInteraction";
+import { PERMISSIONS_LEVEL } from "../enums/permissionsLevel";
 
 export interface CommandInterface {
   data: SlashCommandBuilder | SlashCommandOptionsOnlyBuilder;
   hasCooldown?: boolean;
-  isAdministratorCommand: boolean;
+  permission_level: PERMISSIONS_LEVEL;
   execute: (interaction: CustomInteraction) => Promise<void>;
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a unified permission system for commands, migrate existing commands to use permission levels, and add a new owner-only command for granting experience points.

New Features:
- Add an owner-only addexperience command to grant experience points to users

Enhancements:
- Introduce a PERMISSIONS_LEVEL enum (USER, ADMINISTRATOR, OWNER) to replace the boolean administrator flag on commands
- Enforce permission checks in interactionCreate for USER, ADMINISTRATOR, and OWNER levels
- Migrate existing commands (profil, question, upload) to use the new permission_level property